### PR TITLE
`ci`: add scheduled workflow to run every 2 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 0 */2 * *"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

This PR adds a scheduled trigger to the GitHub Actions CI workflow so it runs automatically every two days, in addition to the existing `push` and `pull_request` triggers.

## Changes

* Added a `schedule` event to the GitHub Actions workflow.
* Configured the workflow to execute automatically every two days using a cron expression.
* Preserved the existing CI behavior for pushes and pull requests to the `main` branch.

## Why

Previously, the CI pipeline only ran when code was pushed or a pull request was opened. As a result, issues caused by external dependency updates, changes in package repositories, or new Python releases could go unnoticed until the next code change.

Running the workflow on a regular schedule helps:

* Detect compatibility issues introduced by dependency updates.
* Verify that the project continues to work across all supported operating systems and Python versions.
* Catch regressions earlier, even when the repository has no recent commits.
* Improve confidence that the package remains installable and functional over time.

## Impact

This change does not modify the application's functionality or test logic. It only extends the CI workflow by introducing periodic automated execution.

## Notes

* The scheduled workflow runs in addition to the existing `push` and `pull_request` triggers.
* GitHub Actions schedules use UTC and may experience slight delays depending on GitHub's infrastructure.
